### PR TITLE
Fixed build process

### DIFF
--- a/.bin/build
+++ b/.bin/build
@@ -13,6 +13,10 @@ NEOFORGE_VERSION="$(cat "$BASE_DIR/pack.toml" | grep "neoforge = " | sed -e 's/n
 
 function urldecode() { : "${*//+/ }"; echo -e "${_//%/\\x}"; }
 
+function urlencode() {
+    python3 -c "from urllib.parse import quote; print(quote('$@'))"
+}
+
 function packwiz-path() {
     packwiz_path="$(command -v packwiz || true)"
     if [[ -z "$packwiz_path" ]]; then
@@ -28,11 +32,12 @@ function download-file() {
     local file=$1
 
     if [[ ! -f "$BASE_DIR/download/$file" ]] && [[ ! -z "${MOD_BASE_URL+x}" ]]; then
-        url="$MOD_BASE_URL/${file/ /%20}"
+        url="$MOD_BASE_URL/$(urlencode "$file")"
         status="$(curl -o /dev/null --silent --head --write-out '%{http_code}\n' "$url")"
         if [[ "$status" == "200" ]]; then
             if ! curl -sL "$MOD_BASE_URL/$file" -o "$BASE_DIR/download/$file" 2>/dev/null 1>&2; then
                 echo "  ✗ ERROR: Failed to download $file from $url"
+
                 return 1
             fi
         else
@@ -48,7 +53,7 @@ function check-upload() {
     local file=$1
 
     if [[ ! -z "${MOD_BASE_URL+x}" ]]; then
-        url="$MOD_BASE_URL/$(echo "$file" | sed "s/ /%20/g")"
+        url="$MOD_BASE_URL/$(urlencode "$file")"
         status="$(curl -o /dev/null --silent --head --write-out '%{http_code}\n' "$url")"
         if [[ "$status" != "200" ]]; then
             echo "$url"
@@ -95,6 +100,12 @@ if [[ "$java_installed" == "false" ]]; then
     "$BASE_DIR/.bin/install-dependencies"
 fi
 
+python_installed="$(type python3 2>/dev/null 1>&2 && echo "true" || echo "false")"
+if [[ "$python_installed" == "false" ]]; then
+    echo "✗ python3 is not installed. Installing dependencies..."
+    "$BASE_DIR/.bin/install-dependencies"
+fi
+
 if [[ "$zip_installed" == "false" ]] || [[ -z "$(packwiz-path)" ]] || [[ "$jq_installed" == "false" ]] || [[ "$java_installed" == "false" ]]; then
     echo "✓ All dependencies verified"
 fi
@@ -117,7 +128,7 @@ if [[ ! -z "${MOD_BASE_URL+x}" ]] && [[ "$MOD_BASE_URL" != "" ]] && [[ "$CI" != 
     echo "Validating file server accessibility..."
     # Test with a known file instead of directory listing (which may be disabled)
     test_file="Cobblemon Interface Modded v1.9.2.zip"
-    test_url="$MOD_BASE_URL/$(echo "$test_file" | sed 's/ /%20/g')"
+    test_url="$MOD_BASE_URL/$(urlencode "$test_file")"
     status="$(curl -o /dev/null --silent --head --write-out '%{http_code}\n' --max-time 10 "$test_url" || echo "000")"
     if [[ "$status" != "200" ]]; then
         echo "✗ FATAL: MOD_BASE_URL is not accessible (HTTP $status)"
@@ -127,8 +138,6 @@ if [[ ! -z "${MOD_BASE_URL+x}" ]] && [[ "$MOD_BASE_URL" != "" ]] && [[ "$CI" != 
         exit 1
     fi
     echo "✓ File server is accessible"
-elif [[ "$CI" == "true" ]]; then
-    echo "Skipping file server validation in CI environment"
 fi
 
 # remove any previous build
@@ -200,7 +209,7 @@ if [[ "$TYPE" == "both" ]] || [[ "$TYPE" == "client" ]]; then
     # workaround for packwiz bug: https://github.com/packwiz/packwiz/issues/295
     echo "Patching CurseForge pack..."
     cd "$BASE_DIR/build"
-    
+
     # verify the zip file exists before trying to unzip
     if [[ ! -f "$zip_file" ]]; then
         echo "ERROR: Expected zip file '$zip_file' not found in build directory"
@@ -208,21 +217,15 @@ if [[ "$TYPE" == "both" ]] || [[ "$TYPE" == "client" ]]; then
         ls -la
         exit 1
     fi
-    
-    unzip "$zip_file" -d "$BASE_DIR/build/client" 2>/dev/null 1>&2
-    rm "$zip_file"
 
-    # patch manifest to add neoforge version
-    cd "$BASE_DIR/build/client"
-    cat "$BASE_DIR/build/client/manifest.json" | jq ".minecraft.modLoaders[0] |= {\"id\": \"neoforge-$NEOFORGE_VERSION\", \"primary\": true}" > "$BASE_DIR/build/client/manifest.tmp.json"
-    mv "$BASE_DIR/build/client/manifest.tmp.json" "$BASE_DIR/build/client/manifest.json"
-
-    # re-zip client pack
-    echo "Packaging client files..."
-    zip -r "$zip_file" * 2>/dev/null 1>&2
-    cd "$BASE_DIR/build"
-    mv "$BASE_DIR/build/client/$zip_file" $BASE_DIR/build/
-    rm -rf "$BASE_DIR/build/client"
+    if ! unzip -p Modified\ Cobblemon\ Plus-11.9.0.zip manifest.json | jq -r .minecraft.modLoaders | grep -q -i neoforge; then
+        if [[ -f "$BASE_DIR/.bin/packwiz" ]]; then
+            rm "$BASE_DIR/.bin/packwiz"
+            echo "packwiz needs upgraded. Re-run build to get latest version of packwiz"
+        else
+            echo "packwiz needs upgraded. Upgrade packwiz using whatever method you used to install it."
+        fi
+    fi
 
     echo "✅ CurseForge client zip exported to $BASE_DIR/build/$zip_file"
     echo -e "=====\n\n"
@@ -254,7 +257,7 @@ if [[ "$TYPE" == "both" ]] || [[ "$TYPE" == "server" ]]; then
     download_count=0
     mod_count=0
     echo "Building server (pass 1/2)..."
-    
+
     # Pre-copy all files from download directory to avoid packwiz installer failures
     if [[ -d "$BASE_DIR/download" ]]; then
         echo "Pre-copying downloaded files..."
@@ -262,12 +265,12 @@ if [[ "$TYPE" == "both" ]] || [[ "$TYPE" == "server" ]]; then
         pre_copied_count=$(find "$BASE_DIR/build/server/mods/" -name "*.jar" | wc -l)
         echo "✓ Pre-copied $pre_copied_count files from download directory"
     fi
-    
+
     # loop over packwiz install output to get mods that need to be downloaded manually
     if [[ "$CI" == "true" ]]; then
         echo "CI environment detected - running packwiz installer simulation"
     fi
-    
+
     while read line; do
         if [[ ! "$line" =~ ^Please\ go\ to ]]; then
             continue
@@ -275,33 +278,20 @@ if [[ "$TYPE" == "both" ]] || [[ "$TYPE" == "server" ]]; then
 
         cf_url="$(echo "$line" | sed -e 's/Please go to \(.*\) and save this file to \(.*\)/\1/')"
         filename="$(basename "$(echo "$line" | sed -e 's/Please go to \(.*\) and save this file to \(.*\)/\2/')")"
-        
+
         if [[ "$CI" == "true" ]]; then
             echo "CI Debug: Found excluded mod request for $filename"
         fi
-        
+
         if [[ -f "mods/$filename" ]] || [[ "$old_filename" == "$filename" ]]; then
             continue
         fi
 
         mod_count=$((mod_count + 1))
         any_download="true"
-        
-        # Check if this mod is configured for CurseForge download
-        mod_toml_file=$(find "$BASE_DIR/mods" -name "*.pw.toml" -exec grep -l "filename = \"$filename\"" {} \; | head -1)
-        if [[ -n "$mod_toml_file" ]] && grep -q "mode = \"metadata:curseforge\"" "$mod_toml_file"; then
-            echo "  ⏭️ Skipping $filename (configured for CurseForge download)"
-            if [[ "$CI" == "true" ]]; then
-                echo "    CI Debug: Found CurseForge mod in excluded list - this suggests packwiz API issues"
-            fi
-            continue
-        fi
-        
+
         if ! download-file "$filename"; then
             echo "  ✗ FATAL: Required mod download failed: $filename"
-            echo "    Build cannot continue without this file"
-            echo "    Please check your MOD_BASE_URL configuration and file availability"
-            exit 1
         fi
         if [[ -f "$BASE_DIR/download/$filename" ]]; then
             cp "$BASE_DIR/download/$filename" "mods/$filename"
@@ -313,13 +303,22 @@ if [[ "$TYPE" == "both" ]] || [[ "$TYPE" == "server" ]]; then
         if [[ ! -f "mods/$filename" ]]; then
             echo "  ✗ FATAL: Required mod file missing after download: $filename"
             echo "    This indicates a critical build failure"
-            echo "    Manual download required from: $cf_url"
-            echo "    Save to: $BASE_DIR/download/$filename"
-            exit 1
+            if [[ "$CI" == "true" ]]; then
+                echo "    File needs to be uploaded for CI continue."
+                echo "    Run locally for more details"
+            else
+                echo "    Manual download required from: $cf_url"
+                echo "    Save to: $BASE_DIR/download/$filename"
+            fi
+            can_continue="false"
         fi
         old_filename="$filename"
     done <<< "$(java -jar $BASE_DIR/download/packwiz-installer-bootstrap.jar -g -s server $BASE_DIR/pack.toml 2>&1)" || true
 
+    if [[ "$can_continue" == "false" ]]; then
+        echo "  ✗ FATAL: Exiting due to missing mod files"
+        exit 1
+    fi
     if [[ "$download_count" -gt 0 ]]; then
         echo "✓ Successfully processed $download_count excluded mods"
     fi
@@ -360,7 +359,7 @@ if [[ "$TYPE" == "both" ]] || [[ "$TYPE" == "server" ]]; then
     # Show progress after second pass
     mods_after_second_pass=$(find "$BASE_DIR/build/server/mods/" -name "*.jar" | wc -l)
     echo "📊 Mods after second pass: $mods_after_second_pass"
-    
+
     if [[ "$mods_after_second_pass" -gt "$mods_before_second_pass" ]]; then
         additional_mods=$((mods_after_second_pass - mods_before_second_pass))
         echo "✓ Successfully downloaded $additional_mods additional mods via packwiz installer"
@@ -370,7 +369,7 @@ if [[ "$TYPE" == "both" ]] || [[ "$TYPE" == "server" ]]; then
 
     echo "Cleaning up packwiz installer files..."
     rm "$BASE_DIR/build/server/packwiz"* 2>/dev/null || true
-    
+
     echo "Updating NeoForge version in server files..."
     sed -i -e "s/MODLOADER_VERSION=.*/MODLOADER_VERSION=$NEOFORGE_VERSION/" "$BASE_DIR/server/variables.txt" 2>/dev/null || true
     cp "$BASE_DIR/server/"* "$BASE_DIR/build/server" 2>/dev/null || true
@@ -378,7 +377,7 @@ if [[ "$TYPE" == "both" ]] || [[ "$TYPE" == "server" ]]; then
 
     final_mod_count=$(find "$BASE_DIR/build/server/mods/" -name "*.jar" | wc -l)
     echo "📊 Final mod count: $final_mod_count"
-    
+
     echo ""
     echo "Creating server ZIP package..."
     zip -r "$server_zip_file" * 2>/dev/null 1>&2
@@ -386,18 +385,18 @@ if [[ "$TYPE" == "both" ]] || [[ "$TYPE" == "server" ]]; then
         echo "✗ ERROR: Failed to create server zip file"
         exit 1
     fi
-    
+
     if [[ -f "$server_zip_file" ]]; then
         echo "Moving server ZIP to build directory..."
         mv "$server_zip_file" "$BASE_DIR/build/" 2>/dev/null || true
-        
+
         # Show final ZIP size
         if [[ -f "$BASE_DIR/build/$server_zip_file" ]]; then
             server_size=$(du -h "$BASE_DIR/build/$server_zip_file" | cut -f1)
             echo "✓ Server zip created successfully: $server_size"
         fi
     fi
-    
+
     echo "Cleaning up temporary server directory..."
     rm -rf "$BASE_DIR/build/server"
     echo "✅ CurseForge server zip exported to $BASE_DIR/build/$server_zip_file"

--- a/.bin/install-dependencies
+++ b/.bin/install-dependencies
@@ -31,10 +31,30 @@ function packwiz-path() {
     fi
 }
 
+to_install=""
 zip_installed="$(type zip 2>/dev/null 1>&2 && echo "true" || echo "false")"
 if [[ "$zip_installed" == "false" ]]; then
-    echo "Installing zip..."
-    install-apt zip
+    to_install="$to_install zip"
+fi
+
+jq_installed="$(type jq 2>/dev/null 1>&2 && echo "true" || echo "false")"
+if [[ "$jq_installed" == "false" ]]; then
+    to_install="$to_install jq"
+fi
+
+java_installed="$(type java 2>/dev/null 1>&2 && echo "true" || echo "false")"
+if [[ "$java_installed" == "false" ]]; then
+    to_install="$to_install default-jre"
+fi
+
+python_installed="$(type python3 2>/dev/null 1>&2 && echo "true" || echo "false")"
+if [[ "$python_installed" == "false" ]]; then
+    to_install="$to_install python3"
+fi
+
+if [[ ! -z "$to_install" ]]; then
+    echo "Installing apt packages: $to_install"
+    install-apt "$to_install"
 fi
 
 if [[ -z "$(packwiz-path)" ]]; then
@@ -43,18 +63,6 @@ if [[ -z "$(packwiz-path)" ]]; then
     unzip packwiz.zip
     rm packwiz.zip
     mv packwiz .bin/packwiz
-fi
-
-jq_installed="$(type jq 2>/dev/null 1>&2 && echo "true" || echo "false")"
-if [[ "$jq_installed" == "false" ]]; then
-    echo "Installing jq..."
-    install-apt jq
-fi
-
-java_installed="$(type java 2>/dev/null 1>&2 && echo "true" || echo "false")"
-if [[ "$java_installed" == "false" ]]; then
-    echo "Installing java..."
-    install-apt default-jre
 fi
 
 echo "Dependencies installed"

--- a/index.toml
+++ b/index.toml
@@ -9563,7 +9563,7 @@ metafile = true
 
 [[files]]
 file = "resourcepacks/cobblemon-interface-modded.pw.toml"
-hash = "2de55c7988d2ebc8754329eaba2853e10f4cb522df05728700c122f397d78765"
+hash = "b773ca99d0539a809df8b88390b7b2f2648abac00d92ca3deb308780c9942276"
 metafile = true
 
 [[files]]
@@ -9592,12 +9592,12 @@ hash = "d56faf1280b0873578367d1fe635449cad63d327a4495d5ef38a57f5a24d6653"
 metafile = true
 
 [[files]]
-file = "shaderpacks/ComplementaryReimagined_r5.5.1 + EuphoriaPatches_1.6.5.zip"
-hash = "4434feaa2deb48c2cd3f75229ae2276b4c4d4af445d66259bdeb67e796bea12c"
+file = "shaderpacks/ComplementaryReimagined_r5.4 + EuphoriaPatches_1.5.2.zip"
+hash = "b1f4742320d7d66217f7f7eb2d74a953396ba3b8682f9ec4d7d700ef6beba4d7"
 
 [[files]]
-file = "shaderpacks/ComplementaryUnbound_r5.5.1 + EuphoriaPatches_1.6.5.zip"
-hash = "8cc87c486a108ffee2797b4cd22eab765b3ccb1f77f4830e7c149e10e308aa36"
+file = "shaderpacks/ComplementaryUnbound_r5.4 + EuphoriaPatches_1.5.2.zip"
+hash = "af0f717d5fe557ed8daee407475dfeb0672d8b1c4c2081bf7f1a9ed9f6a7685b"
 
 [[files]]
 file = "shaderpacks/complementary-reimagined.pw.toml"

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "a224cc8fc1f12e98edb8196c67e8af4fcbc137e692219821a4ac1a130e4b36fa"
+hash = "0e0112738d1aa5c28369e78fac63bd4e2a31fbeca7eefd9471cc8c1513dc1d24"
 
 [versions]
 minecraft = "1.21.1"

--- a/resourcepacks/cobblemon-interface-modded.pw.toml
+++ b/resourcepacks/cobblemon-interface-modded.pw.toml
@@ -1,6 +1,6 @@
 name = "Cobblemon Interface: Modded"
 filename = "Cobblemon Interface Modded v1.9.3.zip"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"


### PR DESCRIPTION
The build process was having issues with file names that needed to be URL encoded. Previously I was just trying to do bash only and manually urlencoding strings by replacing them. bash/GNU utils does not have easy URL encoding method, so I just switched to using Python which most people should already have installed. If it is not installed, it will be auto installed on Debian systems.

Note: **ALL** Resource packs must be labeled as client side only or not require manual download from CF. The build script currently cannot download anything manually that is _not_ a mod.

Changes:

* Replace URL encode method with Python based one
* Verify Python is installed
* Refactor install-dependencies to batch install `apt-get` packages
* Remove hack to patch in NeoForge version into the CF `manifest.json` as the latest version of packwiz finally supports its
* Adds check to make sure the NeoForge version is in the CF `manifest.json`, prompt upgrade if not
* Remove CF excluded list logic
* Remove build failure if it cannot download mod (needed to get manual download message)
* Update messaging for when manual download is needed
* Allow _all_ manual downloads to be displayed before exit instead of failing fast
* Makes `Cobblemon Interface: Modded` resource pack client side only